### PR TITLE
Chore: support the new versioning scheme of Protobuf

### DIFF
--- a/infra/vprotogen/main.go
+++ b/infra/vprotogen/main.go
@@ -120,7 +120,7 @@ func getInstalledProtocVersion(protocPath string) (string, error) {
 	if cmdErr != nil {
 		return "", cmdErr
 	}
-	versionRegexp := regexp.MustCompile(`protoc\s*(\d+\.\d+\.\d+)`)
+	versionRegexp := regexp.MustCompile(`protoc\s*(\d+\.\d+(\.\d)*)`)
 	matched := versionRegexp.FindStringSubmatch(string(output))
 	return matched[1], nil
 }
@@ -129,6 +129,9 @@ func parseVersion(s string, width int) int64 {
 	strList := strings.Split(s, ".")
 	format := fmt.Sprintf("%%s%%0%ds", width)
 	v := ""
+	if len(strList) == 2 {
+		strList = append([]string{"4"}, strList...)
+	}
 	for _, value := range strList {
 		v = fmt.Sprintf(format, v, value)
 	}


### PR DESCRIPTION
Protobuf has changed their versioning scheme to a language-specific one. Basically the major part of versioning is now language-specific and no longer important. 

Current releases are referred to using the minor version e.g. v24.0. The output of `protoc --version` gives like 
`libprotoc 24.0-rc3` while config.pb.go generated by protoc-gen-go still uses `v4.24.0--rc3`.

Check more:
[https://protobuf.dev/news/2022-05-06/](https://protobuf.dev/news/2022-05-06/)
[https://github.com/protocolbuffers/protobuf/issues/11440](https://github.com/protocolbuffers/protobuf/issues/11440)
[https://github.com/protocolbuffers/protobuf/issues/11123](https://github.com/protocolbuffers/protobuf/issues/11123)